### PR TITLE
Allow launching Linux client script from outside its directory

### DIFF
--- a/vpin-studio-ui/VPin-Studio-linux_x64.sh
+++ b/vpin-studio-ui/VPin-Studio-linux_x64.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+cd "$(dirname "$(readlink -f -- "$0")")"
+
 if [[ ! -d zulu11.72.19-ca-fx-jre11.0.23-linux_x64 ]];
 then
 	tar -xvf zulu11.72.19-ca-fx-jre11.0.23-linux_x64.tar.gz


### PR DESCRIPTION
This change updates the Linux client launch script to allow launching it without already being in its directory, to allow launching it via a symlink in the system's path to more easily allow it to be packaged for Linux distributions.

[This page](https://stackoverflow.com/a/17744637) gives a good overview of different ways to do this across different operating systems and shells with different levels of compatibility. Since this script looks to be Linux specific, I went with the most compatible Linux-specific option.

Examples:
```
~> ln -s ~/VPin-Studio/VPin-Studio-linux_x64.sh ~/bin/vpin-studio
```

Without this change:
```
~> vpin-studio
tar: zulu11.72.19-ca-fx-jre11.0.23-linux_x64.tar.gz: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
/home/dmccombs/bin/vpin-studio: line 9: ./zulu11.72.19-ca-fx-jre11.0.23-linux_x64/bin/java: No such file or directory
```

With this change (launches successfully):
```
~> vpin-studio
12-06 06:56:23.966 [Studio Resource Updater] INFO  d.m.v.u.StudioUpdatePreProcessing - Finished resource updates check.
12-06 06:56:24.089 [JavaFX Application Thread] ERROR d.m.v.r.c.VPinStudioClient - Get version failed for http://localhost:8089/
12-06 06:56:24.289 [JavaFX Application Thread] ERROR d.m.v.r.c.VPinStudioClient - Get version failed for http://localhost:8089/
12-06 06:56:24.317 [pool-2-thread-1] ERROR d.m.v.r.c.VPinStudioClient - Get version failed for http://localhost:8089/
12-06 06:56:24.318 [Thread-4] INFO  d.m.v.u.l.LauncherController - Checking connection to 192.168.1.113
12-06 06:56:24.359 [pool-3-thread-1] INFO  o.s.w.c.RestTemplate - HTTP GET http://192.168.1.113:8089/api/v1/preferences/avatar (27ms)
12-06 06:56:24.362 [pool-3-thread-1] INFO  o.s.w.c.RestTemplate - HTTP GET http://192.168.1.113:8089/api/v1/preferences/systemName (3ms)
```