### PR TITLE
Add SortedScoreAdapter for Transformers

### DIFF
--- a/vpin-studio-server/src/main/java/de/mephisto/vpin/server/highscores/parsing/nvram/NvRamHighscoreToRawConverter.java
+++ b/vpin-studio-server/src/main/java/de/mephisto/vpin/server/highscores/parsing/nvram/NvRamHighscoreToRawConverter.java
@@ -28,6 +28,7 @@ public class NvRamHighscoreToRawConverter {
     adapters.add(new SkipFirstListScoreAdapter("godzilla.nv"));
     adapters.add(new NewLineAfterFirstScoreAdapter("kiko_a10.nv"));
     adapters.add(new Anonymous5PlayerScoreAdapter("punchy.nv"));
+    adapters.add(new SortedScoreAdapter("tf_180.nv"));
     adapters.add(new FixTitleScoreAdapter("rs_l6.nv", "TODAY'S HIGHEST SCORES", "ALL TIME HIGHEST SCORES"));
     adapters.add(new SinglePlayerScoreAdapter());
   }

--- a/vpin-studio-server/src/main/java/de/mephisto/vpin/server/highscores/parsing/nvram/adapters/SortedScoreAdapter.java
+++ b/vpin-studio-server/src/main/java/de/mephisto/vpin/server/highscores/parsing/nvram/adapters/SortedScoreAdapter.java
@@ -1,0 +1,76 @@
+package de.mephisto.vpin.server.highscores.parsing.nvram.adapters;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.*;
+import java.util.regex.*;
+
+// E.g. Transformers has a seperate highscore list for Autobots and Decepticons
+// This adapter combines all scores into one list
+public class SortedScoreAdapter implements ScoreNvRamAdapter {
+
+  private String name;
+
+  public SortedScoreAdapter(String name) {
+    this.name = name;
+  }
+
+  public SortedScoreAdapter() {
+
+  }
+
+  @Override
+  public boolean isApplicable(@NonNull String nvRam, @NonNull List<String> lines) {
+    return nvRam.equals(name);
+  }
+
+  @Override
+  public String convert(@NonNull String nvRam, @NonNull List<String> lines) {
+    List<HighScore> scores = new ArrayList<>();
+
+    // Regex for scores with or without thousands seperator (e.g., "OPT 75.000.000", "OPT 30000", "#1 OPT 20.000", OPT 10,000,000)
+    Pattern scorePattern = Pattern.compile("([A-Z]{3})\\s+(\\d+([.,]\\d{3})*)$");
+
+    // Process each line
+    for (String line : lines) {
+      Matcher matcher = scorePattern.matcher(line);
+      if (matcher.find()) {
+        String player = matcher.group(1);
+        String scoreString = matcher.group(2);
+        scoreString = scoreString.replace(".", "");
+        scoreString = scoreString.replace(",","");
+        int score = Integer.parseInt(scoreString);
+        scores.add(new HighScore(player, score));
+      }
+    }
+
+    // Sort scores in descending order
+    scores.sort((a, b) -> Integer.compare(b.getScore(), a.getScore()));
+
+    StringBuilder converted = new StringBuilder();
+    int i = 1;
+    for (HighScore score : scores) {
+      converted.append(String.format("#%d %s     %d%n", i++, score.getPlayer(), score.getScore()));
+    }
+
+    return converted.toString();
+  }
+
+  // Only used in SortedScoreAdapter
+  private class HighScore {
+    private final String player;
+    private final int score;
+
+    public HighScore(String player, int score) {
+      this.player = player;
+      this.score = score;
+    }
+
+    public String getPlayer() {
+      return player;
+    }
+
+    public int getScore() {
+      return score;
+    }
+  }
+}

--- a/vpin-studio-server/src/main/java/de/mephisto/vpin/server/highscores/parsing/nvram/adapters/SortedScoreAdapter.java
+++ b/vpin-studio-server/src/main/java/de/mephisto/vpin/server/highscores/parsing/nvram/adapters/SortedScoreAdapter.java
@@ -35,21 +35,18 @@ public class SortedScoreAdapter implements ScoreNvRamAdapter {
       Matcher matcher = scorePattern.matcher(line);
       if (matcher.find()) {
         String player = matcher.group(1);
-        String scoreString = matcher.group(2);
-        scoreString = scoreString.replace(".", "");
-        scoreString = scoreString.replace(",","");
-        int score = Integer.parseInt(scoreString);
+        String score = matcher.group(2);
         scores.add(new HighScore(player, score));
       }
     }
 
     // Sort scores in descending order
-    scores.sort((a, b) -> Integer.compare(b.getScore(), a.getScore()));
+    scores.sort((a, b) -> Integer.compare(b.getScoreValue(), a.getScoreValue()));
 
     StringBuilder converted = new StringBuilder();
     int i = 1;
     for (HighScore score : scores) {
-      converted.append(String.format("#%d %s     %d%n", i++, score.getPlayer(), score.getScore()));
+      converted.append(String.format("#%d %s     %s%n", i++, score.getPlayer(), score.getScore()));
     }
 
     return converted.toString();
@@ -58,19 +55,28 @@ public class SortedScoreAdapter implements ScoreNvRamAdapter {
   // Only used in SortedScoreAdapter
   private class HighScore {
     private final String player;
-    private final int score;
+    private final String score;
+    private final int scoreValue;
 
-    public HighScore(String player, int score) {
+    public HighScore(String player, String score) {
       this.player = player;
       this.score = score;
+      String scoreToParse = score.replace(".", "");
+      scoreToParse = scoreToParse.replace(",","");
+      this.scoreValue = Integer.parseInt(scoreToParse);
     }
 
     public String getPlayer() {
       return player;
     }
 
-    public int getScore() {
+    public String getScore() {
       return score;
     }
+
+    public int getScoreValue() {
+      return scoreValue;
+    }
+
   }
 }


### PR DESCRIPTION
Added a new adapter to accomodate for tables that have multiple highscore lists that need to be consolidated into one. For example, Transformers has an Autobot and Decepticon highscore list:
```
AUTOBOT
GRAND CHAMPION
OPT        75.000.000

AUTOBOT
HIGH SCORES
#1 JAZ        55.000.000
#2 PWL        40.000.000
#3 IRN        30.000.000
#4 BEE        25.000.000

DECEPTICON
GRAND CHAMPION
MEG        75.000.000

DECEPTICON
HIGH SCORES
#1 STR        55.000.000
#2 SND        40.000.000
#3 SHK        30.000.000
#4 BLK        25.000.000

COMBO CHAMPION
LON   20 COMBOS

BEST COMBO CHAMPION
LON   5-WAY
```
Lines with formatting `(anything)(3-letter-player)(spaces)(score)(end of line)` will be matched and sorted, resulting in:
```
#1 OPT     75.000.000
#2 MEG     75.000.000
#3 JAZ     55.000.000
#4 STR     55.000.000
#5 PWL     40.000.000
#6 SND     40.000.000
#7 IRN     30.000.000
#8 SHK     30.000.000
#9 BEE     25.000.000
#10 BLK     25.000.000
```
