### PR TITLE
Added Tooltips to playlist icons it main table overview

### DIFF
--- a/vpin-studio-ui/src/main/java/de/mephisto/vpin/ui/tables/TableOverviewController.java
+++ b/vpin-studio-ui/src/main/java/de/mephisto/vpin/ui/tables/TableOverviewController.java
@@ -1343,6 +1343,7 @@ public class TableOverviewController extends BaseTableController<GameRepresentat
           Label playlistIcon = WidgetFactory.createPlaylistIcon(match, uiSettings);
           if (match.getId() >= 0) {
             Button plButton = new Button("", playlistIcon.getGraphic());
+            plButton.setTooltip(new Tooltip(match.getName()));
             plButton.getStyleClass().add("ghost-button-tiny");
             plButton.setOnAction(new EventHandler<ActionEvent>() {
               @Override


### PR DESCRIPTION
I would personally like to use the wheels in some way (maybe make the wheels the tooltip?), but for now I added tooltips to the icons so that a user can tell what custom playlists a table belongs to a little easier. 