### PR TITLE
Fix for Music folder validation - Issue 1045

### DIFF
--- a/vpin-studio-server/src/main/java/de/mephisto/vpin/server/music/MusicService.java
+++ b/vpin-studio-server/src/main/java/de/mephisto/vpin/server/music/MusicService.java
@@ -63,7 +63,7 @@ public class MusicService {
   }
 
   public List<File> getMp3Files(Game game) {
-    File musicFolder = folderLookupService.getMusicFolder(game);
+    File musicFolder = folderLookupService.getGameMusicFolder(game);
     if (musicFolder == null || !musicFolder.exists()) {
       return Collections.emptyList();
     }
@@ -100,7 +100,7 @@ public class MusicService {
   }
 
   public List<String> getMissingMp3Files(Game game) {
-    File musicFolder = folderLookupService.getMusicFolder(game);
+    File musicFolder = folderLookupService.getGameMusicFolder(game);
     if (musicFolder == null || !musicFolder.exists()) {
       return Collections.emptyList();
     }


### PR DESCRIPTION
Changed method used for checking MP3's to getGameMusicFolder since game is passed to the method, this does a more thorough check of different possible installed directories. 