### PR TITLE
webp-support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,8 @@
         <logback.version>1.5.32</logback.version>
         <slf4j.version>2.0.17</slf4j.version>
         <jspecify.version>1.0.0</jspecify.version>
+        <twelvemonkeys.version>3.13.1</twelvemonkeys.version>
+
 
         <!-- Plugin versions -->
         <maven-dependency-plugin.version>3.9.0</maven-dependency-plugin.version>

--- a/vpin-studio-commons/pom.xml
+++ b/vpin-studio-commons/pom.xml
@@ -15,6 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
     </properties>
 
     <dependencies>
@@ -190,6 +191,13 @@
         <dependency>
             <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <!-- WebP Dependency -->
+        <dependency>
+            <groupId>com.twelvemonkeys.imageio</groupId>
+            <artifactId>imageio-webp</artifactId>
+            <version>${twelvemonkeys.version}</version>
         </dependency>
     </dependencies>
 

--- a/vpin-studio-commons/src/main/java/de/mephisto/vpin/commons/utils/CommonImageUtil.java
+++ b/vpin-studio-commons/src/main/java/de/mephisto/vpin/commons/utils/CommonImageUtil.java
@@ -14,13 +14,18 @@ import javafx.scene.image.WritableImage;
 import org.imgscalr.Scalr;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.jspecify.annotations.Nullable;
+
 
 import javax.imageio.ImageIO;
+import javax.net.ssl.HttpsURLConnection;
 import java.awt.*;
 import java.awt.geom.Ellipse2D;
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.lang.invoke.MethodHandles;
+import java.net.HttpURLConnection;
+import java.net.URI;
 
 public class CommonImageUtil {
   private final static Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -267,4 +272,72 @@ public class CommonImageUtil {
     long duration = System.currentTimeMillis() - writeDuration;
     LOG.info("Writing " + file.getAbsolutePath() + " took " + duration + "ms.");
   }
+
+    /**
+     * Loads a JavaFX {@link Image} from an HTTP/HTTPS URL, with transparent
+     * handling for servers that return WebP data despite a {@code .png} extension
+     * or {@code image/png} Content-Type header.
+     *
+     * <p>The response bytes are fetched first so the format can be sniffed before
+     * handing off to the appropriate decoder:
+     * <ul>
+     *   <li>WebP ({@code RIFF....WEBP} header): decoded via
+     *       {@link ImageIO} using the TwelveMonkeys {@code imageio-webp} plugin,
+     *       then converted to a JavaFX {@link Image} via {@link SwingFXUtils}.</li>
+     *   <li>Everything else: passed directly to {@code new Image(InputStream)},
+     *       which handles PNG, JPEG, GIF, and APNG via the registered loaders.</li>
+     * </ul>
+     *
+     * @param -url the image URL (HTTP or HTTPS)
+     * @return the decoded {@link Image}, or {@code null} if loading failed
+     *         (error is logged; the caller need not log again)
+     */
+
+    @Nullable
+    public static Image loadImageFromUrl(String url) {
+        try {
+            HttpURLConnection conn = (HttpURLConnection) URI.create(url).toURL().openConnection();
+            conn.setConnectTimeout(5_000);
+            conn.setReadTimeout(30_000);
+            conn.setRequestProperty("Accept", "image/*");
+
+            try (InputStream is = conn.getInputStream()) {
+                byte[] bytes = is.readAllBytes();
+
+                if (isWebP(bytes)) {
+                    LOG.info("Detected WebP content at URL, decoding via TwelveMonkeys ImageIO: {}", url);
+                    BufferedImage buffered = ImageIO.read(new ByteArrayInputStream(bytes));
+                    if (buffered == null) {
+                        LOG.error("WebP decode returned null for URL: {}", url);
+                        return null;
+                    }
+                    return SwingFXUtils.toFXImage(buffered, null);
+                }
+
+                // All other formats — delegate to JavaFX's registered image loaders
+                return new Image(new ByteArrayInputStream(bytes));
+            } finally {
+                conn.disconnect();
+            }
+        } catch (Exception e) {
+            LOG.error("Failed to load image from URL {}: {}", url, e.getMessage(), e);
+            return null;
+        }
+    }
+
+    /**
+     * Returns {@code true} if {@code bytes} begins with a WebP file header
+     * ({@code RIFF} at offset 0, {@code WEBP} at offset 8).
+     */
+    private static boolean isWebP(byte[] bytes) {
+        return bytes.length >= 12
+                && bytes[0]  == (byte) 'R'
+                && bytes[1]  == (byte) 'I'
+                && bytes[2]  == (byte) 'F'
+                && bytes[3]  == (byte) 'F'
+                && bytes[8]  == (byte) 'W'
+                && bytes[9]  == (byte) 'E'
+                && bytes[10] == (byte) 'B'
+                && bytes[11] == (byte) 'P';
+    }
 }

--- a/vpin-studio-commons/src/main/java/de/mephisto/vpin/commons/utils/CommonImageUtil.java
+++ b/vpin-studio-commons/src/main/java/de/mephisto/vpin/commons/utils/CommonImageUtil.java
@@ -14,18 +14,16 @@ import javafx.scene.image.WritableImage;
 import org.imgscalr.Scalr;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.jspecify.annotations.Nullable;
 
 
 import javax.imageio.ImageIO;
-import javax.net.ssl.HttpsURLConnection;
+import org.apache.commons.io.FilenameUtils;
 import java.awt.*;
 import java.awt.geom.Ellipse2D;
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.lang.invoke.MethodHandles;
-import java.net.HttpURLConnection;
-import java.net.URI;
+
 
 public class CommonImageUtil {
   private final static Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -274,58 +272,6 @@ public class CommonImageUtil {
   }
 
     /**
-     * Loads a JavaFX {@link Image} from an HTTP/HTTPS URL, with transparent
-     * handling for servers that return WebP data despite a {@code .png} extension
-     * or {@code image/png} Content-Type header.
-     *
-     * <p>The response bytes are fetched first so the format can be sniffed before
-     * handing off to the appropriate decoder:
-     * <ul>
-     *   <li>WebP ({@code RIFF....WEBP} header): decoded via
-     *       {@link ImageIO} using the TwelveMonkeys {@code imageio-webp} plugin,
-     *       then converted to a JavaFX {@link Image} via {@link SwingFXUtils}.</li>
-     *   <li>Everything else: passed directly to {@code new Image(InputStream)},
-     *       which handles PNG, JPEG, GIF, and APNG via the registered loaders.</li>
-     * </ul>
-     *
-     * @param -url the image URL (HTTP or HTTPS)
-     * @return the decoded {@link Image}, or {@code null} if loading failed
-     *         (error is logged; the caller need not log again)
-     */
-
-    @Nullable
-    public static Image loadImageFromUrl(String url) {
-        try {
-            HttpURLConnection conn = (HttpURLConnection) URI.create(url).toURL().openConnection();
-            conn.setConnectTimeout(5_000);
-            conn.setReadTimeout(30_000);
-            conn.setRequestProperty("Accept", "image/*");
-
-            try (InputStream is = conn.getInputStream()) {
-                byte[] bytes = is.readAllBytes();
-
-                if (isWebP(bytes)) {
-                    LOG.info("Detected WebP content at URL, decoding via TwelveMonkeys ImageIO: {}", url);
-                    BufferedImage buffered = ImageIO.read(new ByteArrayInputStream(bytes));
-                    if (buffered == null) {
-                        LOG.error("WebP decode returned null for URL: {}", url);
-                        return null;
-                    }
-                    return SwingFXUtils.toFXImage(buffered, null);
-                }
-
-                // All other formats — delegate to JavaFX's registered image loaders
-                return new Image(new ByteArrayInputStream(bytes));
-            } finally {
-                conn.disconnect();
-            }
-        } catch (Exception e) {
-            LOG.error("Failed to load image from URL {}: {}", url, e.getMessage(), e);
-            return null;
-        }
-    }
-
-    /**
      * Returns {@code true} if {@code bytes} begins with a WebP file header
      * ({@code RIFF} at offset 0, {@code WEBP} at offset 8).
      */
@@ -341,24 +287,38 @@ public class CommonImageUtil {
                 && bytes[11] == (byte) 'P';
     }
 
-    public static void convertWebPToPngIfNeeded(File file) {
+    public static File convertWebPToPngIfNeeded(File file) {
         try {
             byte[] header = new byte[12];
             try (FileInputStream fis = new FileInputStream(file)) {
                 if (fis.read(header) < 12 || !isWebP(header)) {
-                    return;
+                    return file;
                 }
             }
             LOG.info("Detected WebP content in {}, converting to PNG", file.getAbsolutePath());
             BufferedImage image = ImageIO.read(file);
             if (image == null) {
                 LOG.error("WebP decode returned null for file: {}", file.getAbsolutePath());
-                return;
+                return file;
             }
-            ImageIO.write(image, "PNG", file);
-            LOG.info("Converted WebP to PNG: {}", file.getAbsolutePath());
+
+            // If the file has a .webp extension, write to a new .png file and delete the original
+            File target = file;
+            if (FilenameUtils.getExtension(file.getName()).equalsIgnoreCase("webp")) {
+                target = new File(file.getParentFile(), FilenameUtils.getBaseName(file.getName()) + ".png");
+            }
+
+            ImageIO.write(image, "PNG", target);
+
+            if (!target.equals(file) && !file.delete()) {
+                LOG.warn("Failed to delete original WebP file: {}", file.getAbsolutePath());
+            }
+
+            LOG.info("Converted WebP to PNG: {}", target.getAbsolutePath());
+            return target;
         } catch (Exception e) {
             LOG.error("Failed to convert WebP file {}: {}", file.getAbsolutePath(), e.getMessage(), e);
+            return file;
         }
     }
 }

--- a/vpin-studio-commons/src/main/java/de/mephisto/vpin/commons/utils/CommonImageUtil.java
+++ b/vpin-studio-commons/src/main/java/de/mephisto/vpin/commons/utils/CommonImageUtil.java
@@ -340,4 +340,25 @@ public class CommonImageUtil {
                 && bytes[10] == (byte) 'B'
                 && bytes[11] == (byte) 'P';
     }
+
+    public static void convertWebPToPngIfNeeded(File file) {
+        try {
+            byte[] header = new byte[12];
+            try (FileInputStream fis = new FileInputStream(file)) {
+                if (fis.read(header) < 12 || !isWebP(header)) {
+                    return;
+                }
+            }
+            LOG.info("Detected WebP content in {}, converting to PNG", file.getAbsolutePath());
+            BufferedImage image = ImageIO.read(file);
+            if (image == null) {
+                LOG.error("WebP decode returned null for file: {}", file.getAbsolutePath());
+                return;
+            }
+            ImageIO.write(image, "PNG", file);
+            LOG.info("Converted WebP to PNG: {}", file.getAbsolutePath());
+        } catch (Exception e) {
+            LOG.error("Failed to convert WebP file {}: {}", file.getAbsolutePath(), e.getMessage(), e);
+        }
+    }
 }

--- a/vpin-studio-commons/src/main/java/de/mephisto/vpin/commons/utils/media/ImageViewer.java
+++ b/vpin-studio-commons/src/main/java/de/mephisto/vpin/commons/utils/media/ImageViewer.java
@@ -1,19 +1,30 @@
 package de.mephisto.vpin.commons.utils.media;
 
 import de.mephisto.vpin.commons.utils.JFXFuture;
+import de.mephisto.vpin.commons.utils.CommonImageUtil;
 import de.mephisto.vpin.restclient.frontend.VPinScreen;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
 
 public class ImageViewer extends AssetMediaPlayer {
+    private final static Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private ImageView imageView;
 
   public void render(String url,  @Nullable VPinScreen screen, boolean invertPlayfield) {
     setLoading();
-    JFXFuture.supplyAsync(() -> new Image(url)).thenAcceptLater(i -> { 
+    JFXFuture.supplyAsync(() -> CommonImageUtil.loadImageFromUrl(url)).thenAcceptLater(i -> {
+        assert i != null;
+        if (i.isError()) {
+            LOG.error("Image failed to load: {}", i.getException().getMessage(), i.getException());
+            return;
+        }
       renderImage(i, screen, invertPlayfield);
     });
   }

--- a/vpin-studio-commons/src/main/java/de/mephisto/vpin/commons/utils/media/ImageViewer.java
+++ b/vpin-studio-commons/src/main/java/de/mephisto/vpin/commons/utils/media/ImageViewer.java
@@ -19,8 +19,8 @@ public class ImageViewer extends AssetMediaPlayer {
 
   public void render(String url,  @Nullable VPinScreen screen, boolean invertPlayfield) {
     setLoading();
-    JFXFuture.supplyAsync(() -> CommonImageUtil.loadImageFromUrl(url)).thenAcceptLater(i -> {
-        assert i != null;
+      JFXFuture.supplyAsync(() -> new Image(url)).thenAcceptLater(i -> {
+          assert i != null;
         if (i.isError()) {
             LOG.error("Image failed to load: {}", i.getException().getMessage(), i.getException());
             return;

--- a/vpin-studio-server/pom.xml
+++ b/vpin-studio-server/pom.xml
@@ -25,6 +25,8 @@
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <jspecify.version>1.0.0</jspecify.version>
         <spotbugs.version>4.9.8</spotbugs.version>
+        <twelvemonkeys.version>3.13.1</twelvemonkeys.version>
+
 
         <!-- Plugin versions -->
         <maven-dependency-plugin.version>3.9.0</maven-dependency-plugin.version>
@@ -766,6 +768,8 @@
                                 <ignoredUnusedDeclaredDependency>org.imgscalr:imgscalr-lib</ignoredUnusedDeclaredDependency>
                                 <!-- Test aggregation jar -->
                                 <ignoredUnusedDeclaredDependency>org.junit.jupiter:junit-jupiter</ignoredUnusedDeclaredDependency>
+                                <!--Twelvemonkeys Image Processing -->
+                                <ignoredUnusedDeclaredDependency>com.twelvemonkeys.imageio:imageio-webp</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>

--- a/vpin-studio-server/src/main/java/de/mephisto/vpin/server/assets/TableAssetsService.java
+++ b/vpin-studio-server/src/main/java/de/mephisto/vpin/server/assets/TableAssetsService.java
@@ -1,5 +1,6 @@
 package de.mephisto.vpin.server.assets;
 
+import de.mephisto.vpin.commons.utils.CommonImageUtil;
 import de.mephisto.vpin.connectors.assets.AssetLookupStrategy;
 import de.mephisto.vpin.connectors.assets.TableAsset;
 import de.mephisto.vpin.connectors.assets.TableAssetSource;
@@ -116,6 +117,7 @@ public class TableAssetsService {
       catch (Exception e) {
         LOG.error("Failed to execute download: {}", e.getMessage(), e);
       }
+      CommonImageUtil.convertWebPToPngIfNeeded(target);
     }
   }
 

--- a/vpin-studio-server/src/main/java/de/mephisto/vpin/server/assets/TableAssetsService.java
+++ b/vpin-studio-server/src/main/java/de/mephisto/vpin/server/assets/TableAssetsService.java
@@ -117,7 +117,7 @@ public class TableAssetsService {
       catch (Exception e) {
         LOG.error("Failed to execute download: {}", e.getMessage(), e);
       }
-      CommonImageUtil.convertWebPToPngIfNeeded(target);
+      target = CommonImageUtil.convertWebPToPngIfNeeded(target);
     }
   }
 

--- a/vpin-studio-server/src/main/java/de/mephisto/vpin/server/games/GameMediaResource.java
+++ b/vpin-studio-server/src/main/java/de/mephisto/vpin/server/games/GameMediaResource.java
@@ -1,5 +1,6 @@
 package de.mephisto.vpin.server.games;
 
+import de.mephisto.vpin.commons.utils.CommonImageUtil;
 import de.mephisto.vpin.connectors.assets.TableAsset;
 import de.mephisto.vpin.connectors.assets.TableAssetSource;
 import de.mephisto.vpin.connectors.assets.TableAssetsAdapter;
@@ -419,6 +420,9 @@ public class GameMediaResource {
       }
 
       String suffix = FilenameUtils.getExtension(file.getOriginalFilename());
+      if ("webp".equalsIgnoreCase(suffix)) {
+          suffix = "png";
+      }
       File out = gameMediaService.uniqueMediaAsset(gameId, screen, suffix, append);
       if (out == null) {
         LOG.error("No game found for media upload.");
@@ -426,7 +430,8 @@ public class GameMediaResource {
       }
 
       LOG.info("Uploading {}", out.getAbsolutePath());
-      UploadUtil.upload(file, out);
+      UploadUtil.upload(file,out);
+      out = CommonImageUtil.convertWebPToPngIfNeeded(out);
 
       if (vPinScreen != null) {
         VPinScreen loadingScreen = VPinScreen.valueOfScreen(vPinScreen);

--- a/vpin-studio-ui/src/main/java/de/mephisto/vpin/ui/tables/MediaTypesSelector.java
+++ b/vpin-studio-ui/src/main/java/de/mephisto/vpin/ui/tables/MediaTypesSelector.java
@@ -20,6 +20,8 @@ public class MediaTypesSelector {
       fileSelection.add("*.jpg");
       fileSelection.add("*.png");
       fileSelection.add("*.apng");
+      fileSelection.add("*.webp");
+
     }
     else {
       fileSelection.add("*.jpg");

--- a/vpin-studio-ui/src/main/java/de/mephisto/vpin/ui/tables/dialogs/TableAssetManagerPane.java
+++ b/vpin-studio-ui/src/main/java/de/mephisto/vpin/ui/tables/dialogs/TableAssetManagerPane.java
@@ -69,7 +69,7 @@ public class TableAssetManagerPane<P extends TableAssetManagerPane.MediaPane> ex
     audio = factory.createPane(this, "Audio", VPinScreen.Audio, "mp3");
     loading = factory.createPane(this, "Loading", VPinScreen.Loading, "mp4");
     other2 = factory.createPane(this, "Other2", VPinScreen.Other2, "mp4", "png", "jpg");
-    wheel = factory.createPane(this, "Wheel", VPinScreen.Wheel, "apng", "png", "jpg");
+    wheel = factory.createPane(this, "Wheel", VPinScreen.Wheel, "apng", "png", "jpg", "webp");
     logo = factory.createPane(this, "Logo", VPinScreen.Logo, "png", "jpg");
 
     allpanes = Arrays.asList(


### PR DESCRIPTION
Reworked to create webp support by converting to .png on download or upload when writing to disk. This handles both .webp files and files that are webp but with a different extension Issue #1081